### PR TITLE
Fix consensus builder pgp fingerprint

### DIFF
--- a/vulnerability-reports.md
+++ b/vulnerability-reports.md
@@ -9,7 +9,7 @@ At a minimum, the report must contain the following:
 * Steps to reproduce the issue.
 
 Optionally, reports that are emailed can be encrypted with PGP. You should use
-PGP key fingerprint E9C0 59EC 0D32 64FA B35F 94AD 465B F9F6 F8EB 475.
+PGP key fingerprint E9C0 59EC 0D32 64FA B35F 94AD 465B F9F6 F8EB 475A.
 
 Please do not use the GitHub issue tracker to submit vulnerability reports. The
 issue tracker is intended for bug reports and to make feature requests.


### PR DESCRIPTION
* **What does this PR do?**
Appends missing trailing `A` to Justin's PGP fingerprint
The (supposedly) correct fingerprint can be queried at:
https://pgp.mit.edu/pks/lookup?search=justin+cappos&fingerprint=on

* **Who do you think should review this PR?**
@vladimir-v-diaz, @JustinCappos

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (e.g., did you update the docstrings?)

   - All builds are passing (did you run the tests locally?)

   - Code follows the [style guide](https://github.com/secure-systems-lab/code-style-guidelines)

